### PR TITLE
Improved naming about snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ declare(ticks=2); // this declaration is important (N=2)
 
 namespace PetrKnap\Profiler;
 
-$profiling = Profiling::start(listenToTicks: true);
+$profiling = Profiling::start(snapshotOnTick: true);
 (fn () => 'something')();
 $profile = $profiling->finish();
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -18,13 +18,13 @@ use PetrKnap\Optional\OptionalInt;
  */
 final class Profile implements ProcessableProfileInterface, ProfileWithOutputInterface
 {
-    public const DO_NOT_LISTEN_TO_TICKS = false;
+    public const DO_NOT_SNAPSHOT_ON_TICK = false;
 
     private const MICROTIME_FORMAT = '%.6f';
     private const SORTED_BY_TIME = true;
 
     private ProfileState $state;
-    private bool|null $isListeningToTicks;
+    private bool|null $isSnapshotingOnTick;
     private OptionalFloat $timeBefore;
     private OptionalInt $memoryUsageBefore;
     private OptionalFloat $timeAfter;
@@ -43,10 +43,10 @@ final class Profile implements ProcessableProfileInterface, ProfileWithOutputInt
     private Optional $outputOption;
 
     public function __construct(
-        bool $listenToTicks = self::DO_NOT_LISTEN_TO_TICKS,
+        bool $snapshotOnTick = self::DO_NOT_SNAPSHOT_ON_TICK,
     ) {
         $this->state = ProfileState::Created;
-        $this->isListeningToTicks = $listenToTicks ? false : null;
+        $this->isSnapshotingOnTick = $snapshotOnTick ? false : null;
         $this->timeBefore = OptionalFloat::empty();
         $this->memoryUsageBefore = OptionalInt::empty();
         $this->timeAfter = OptionalFloat::empty();
@@ -56,7 +56,7 @@ final class Profile implements ProcessableProfileInterface, ProfileWithOutputInt
 
     public function __destruct()
     {
-        $this->unregisterTickHandler();
+        $this->unregisterTickSnapshot();
     }
 
     public function getState(): ProfileState
@@ -77,7 +77,7 @@ final class Profile implements ProcessableProfileInterface, ProfileWithOutputInt
         $this->timeBefore = OptionalFloat::of(microtime(as_float: true));
         $this->memoryUsageBefore = OptionalInt::of(memory_get_usage(real_usage: true));
 
-        $this->registerTickHandler();
+        $this->registerTickSnapshot();
     }
 
     /**
@@ -85,7 +85,7 @@ final class Profile implements ProcessableProfileInterface, ProfileWithOutputInt
      */
     public function finish(): void
     {
-        $this->unregisterTickHandler();
+        $this->unregisterTickSnapshot();
 
         if ($this->state !== ProfileState::Started) {
             throw new Exception\ProfileCouldNotBeFinished();
@@ -99,23 +99,23 @@ final class Profile implements ProcessableProfileInterface, ProfileWithOutputInt
     /**
      * @throws Exception\ProfileCouldNotRegisterTickHandler
      */
-    public function registerTickHandler(): void
+    public function registerTickSnapshot(): void
     {
-        if ($this->isListeningToTicks === false) {
-            register_tick_function([$this, 'tickHandler']) or throw new Exception\ProfileCouldNotRegisterTickHandler();
-            $this->isListeningToTicks = true;
+        if ($this->isSnapshotingOnTick === false) {
+            register_tick_function([$this, 'snapshot']) or throw new Exception\ProfileCouldNotRegisterTickHandler();
+            $this->isSnapshotingOnTick = true;
         }
     }
 
-    public function unregisterTickHandler(): void
+    public function unregisterTickSnapshot(): void
     {
-        if ($this->isListeningToTicks === true) {
-            unregister_tick_function([$this, 'tickHandler']);
-            $this->isListeningToTicks = false;
+        if ($this->isSnapshotingOnTick === true) {
+            unregister_tick_function([$this, 'snapshot']);
+            $this->isSnapshotingOnTick = false;
         }
     }
 
-    public function tickHandler(): void
+    public function snapshot(): void
     {
         $this->memoryUsages[sprintf(self::MICROTIME_FORMAT, microtime(as_float: true))] = memory_get_usage(real_usage: true);
     }

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -6,14 +6,22 @@ namespace PetrKnap\Profiler;
 
 /* final */class Profiler implements ProfilerInterface
 {
+    /**
+     * @param bool $snapshotOnTick if true, it will do snapshot on each tick
+     */
     public function __construct(
-        private readonly bool $listenToTicks = Profile::DO_NOT_LISTEN_TO_TICKS,
+        private readonly bool $snapshotOnTick = Profile::DO_NOT_SNAPSHOT_ON_TICK,
+        /**
+         * @deprecated
+         * @todo remove it
+         */
+        private readonly bool $listenToTicks = Profile::DO_NOT_SNAPSHOT_ON_TICK,
     ) {
     }
 
     public function profile(callable $callable): ProcessableProfileInterface & ProfileWithOutputInterface
     {
-        $profiling = Profiling::start($this->listenToTicks);
+        $profiling = Profiling::start($this->snapshotOnTick, $this->listenToTicks);
         $output = $callable(Profiling::createNestedProfiler($profiling));
         /** @var Profile<mixed> $profile */
         $profile = $profiling->finish();

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -26,20 +26,20 @@ final class ProfileTest extends TestCase
         self::assertSame([$child1, $child2], $parent->getChildren());
     }
 
-    #[DataProvider('dataListensToTicks')]
-    public function testListensToTicks(bool|null $shouldItListen): void
+    #[DataProvider('dataSnapshotsOnTick')]
+    public function testSnapshotsOnTick(bool|null $shouldItSnapshot): void
     {
-        $profile = $shouldItListen === null ? new Profile() : new Profile(listenToTicks: $shouldItListen);
+        $profile = $shouldItSnapshot === null ? new Profile() : new Profile(snapshotOnTick: $shouldItSnapshot);
         $profile->start();
         for ($i = 0; $i < 5; $i++) {
             $i = (fn (int $i): int => $i)($i);
         }
         $profile->finish();
 
-        self::assertCount($shouldItListen === true ? 9 : 2, $profile->getMemoryUsages());
+        self::assertCount($shouldItSnapshot === true ? 9 : 2, $profile->getMemoryUsages());
     }
 
-    public static function dataListensToTicks(): array
+    public static function dataSnapshotsOnTick(): array
     {
         return [
             'default' => [null],


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Which class better informs that the object will do snapshot on each tick - A, or B?
>> ```php
>> class A {
>>     public function __construct(bool $listenToTicks) {}
>> }
>> class B {
>>     public function __construct(bool $snapshotOnTick) {}
>> }
>> ```
>
> Class B does a better job of making it clear that the object will take a snapshot on each tick. The constructor parameter `snapshotOnTick` directly conveys this intention. Clear communication in code is crucial, and B nails it. Does it resonate with your intent?
>
>> Is there any way to do it better?
>
> Definitely. We can improve clarity and ensure the class’s purpose is immediately evident.
>
> Consider using a more descriptive parameter name, maybe even adding a docblock to highlight the intent.
> ```php
> class SnapshotOnTick {
>     /**
>      * @param bool $enableSnapshotOnTick If true, the object will take a snapshot on each tick.
>      */
>     public function __construct(bool $enableSnapshotOnTick) {}
> }
> ```
> 
> Here, the class name `SnapshotOnTick` combined with the parameter `enableSnapshotOnTick` makes it abundantly clear what the class is designed to do. Adding a docblock ensures that future developers understand the exact behavior and purpose of the parameter.
>
> How does that feel? Clearer, right?
