### PR TITLE
Added ability to snapshot on `ProfilerInterface`

### DIFF
--- a/src/Exception/ParentProfileIsNotStarted.php
+++ b/src/Exception/ParentProfileIsNotStarted.php
@@ -8,6 +8,8 @@ use LogicException;
 
 /**
  * @internal exception should never be thrown out
+ *
+ * @todo rename to `ProfilerCouldNotProfileOutsideParentProfile`
  */
 final class ParentProfileIsNotStarted extends LogicException implements ProfilerException
 {

--- a/src/Exception/ProfilerCouldNotSnapshotOutsideParentProfile.php
+++ b/src/Exception/ProfilerCouldNotSnapshotOutsideParentProfile.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\Profiler\Exception;
+
+use LogicException;
+
+final class ProfilerCouldNotSnapshotOutsideParentProfile extends LogicException implements ProfilerException
+{
+}

--- a/src/NullProfiler.php
+++ b/src/NullProfiler.php
@@ -45,4 +45,8 @@ final class NullProfiler implements ProfilerInterface
             }
         };
     }
+
+    public function snapshot(): void
+    {
+    }
 }

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -29,4 +29,9 @@ namespace PetrKnap\Profiler;
 
         return $profile; // @phpstan-ignore return.type
     }
+
+    public function snapshot(): void
+    {
+        throw new Exception\ProfilerCouldNotSnapshotOutsideParentProfile();
+    }
 }

--- a/src/ProfilerInterface.php
+++ b/src/ProfilerInterface.php
@@ -14,4 +14,9 @@ interface ProfilerInterface
      * @return ProcessableProfileInterface<TOutput> & ProfileWithOutputInterface<TOutput>
      */
     public function profile(callable $callable): ProcessableProfileInterface & ProfileWithOutputInterface;
+
+    /**
+     * @throws Exception\ProfilerCouldNotSnapshotOutsideParentProfile
+     */
+    public function snapshot(): void;
 }

--- a/src/Profiling.php
+++ b/src/Profiling.php
@@ -88,6 +88,14 @@ final class Profiling
                     $this->parentProfile->registerTickSnapshot();
                 }
             }
+
+            public function snapshot(): void
+            {
+                if ($this->parentProfile->getState() !== ProfileState::Started) {
+                    throw new Exception\ProfilerCouldNotSnapshotOutsideParentProfile();
+                }
+                $this->parentProfile->snapshot();
+            }
         };
     }
 

--- a/tests/NullProfilerTest.php
+++ b/tests/NullProfilerTest.php
@@ -41,4 +41,13 @@ final class NullProfilerTest extends TestCase
         self::assertFalse($processorWasCalled);
         self::assertSame('output', $output);
     }
+
+    public function testSnapshotDoesNotThrow(): void
+    {
+        $profiler = new NullProfiler();
+
+        $profiler->snapshot();
+
+        self::assertTrue(true);
+    }
 }

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -37,4 +37,22 @@ final class ProfilerTest extends TestCase
 
         self::assertSame('output', $profile->getOutput());
     }
+
+    public function testSnapshotsOnParentProfile(): void
+    {
+        $profiler = new Profiler();
+
+        $profile = $profiler->profile(static fn (ProfilerInterface $profiler) => $profiler->snapshot());
+
+        self::assertCount(2 + 1, $profile->getMemoryUsages());
+    }
+
+    public function testSnapshotsThrowsOutsideProfile(): void
+    {
+        $profiler = new Profiler();
+
+        self::expectException(Exception\ProfilerCouldNotSnapshotOutsideParentProfile::class);
+
+        $profiler->snapshot();
+    }
 }


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the `snapshot` method from following code for me?
>> ```php
>> interface ProfilerInterface
>> {
>>     /**
>>      * @template TOutput of mixed
>>      *
>>      * @param callable(self): TOutput $callable
>>      *
>>      * @return ProcessableProfileInterface<TOutput> & ProfileWithOutputInterface<TOutput>
>>      */
>>     public function profile(callable $callable): ProcessableProfileInterface & ProfileWithOutputInterface;
>> 
>>     /**
>>      * @throws Exception\ProfilerCouldNotSnapshotOutsideProfile
>>      */
>>     public function snapshot(): void;
>> }
>> ```
>
> The `snapshot` method in the `ProfilerInterface` is designed to take a snapshot during profiling. If it’s called outside of a profiling session, it throws a `ProfilerCouldNotSnapshotOutsideProfile` exception.
>
> Got more code you want me to break down?
>
>> Could you show me how to use the `snapshot` method?
>
> Absolutely. Here’s a practical example of how to use the `ProfilerInterface` with the methods defined, focusing on the `snapshot` method:
>
> First, let’s define a concrete implementation of the `ProfilerInterface`:
> ```php
> interface ProfilerInterface {
>     /**
>      * @template TOutput of mixed
>      * @param callable(self): TOutput $callable
>      * @return ProcessableProfileInterface<TOutput> & ProfileWithOutputInterface<TOutput>
>      */
>     public function profile(callable $callable): ProcessableProfileInterface & ProfileWithOutputInterface;
> 
>     /**
>      * @throws Exception\ProfilerCouldNotSnapshotOutsideProfile
>      */
>     public function snapshot(): void;
> }
> 
> class Profiler implements ProfilerInterface {
>     private $isProfiling = false;
>     
>     public function profile(callable $callable): ProcessableProfileInterface & ProfileWithOutputInterface {
>         $this->isProfiling = true;
>         $output = $callable($this);
>         $this->isProfiling = false;
>         
>         return new ProcessableProfile($output); // Assuming appropriate class implementations
>     }
> 
>     public function snapshot(): void {
>         if (!$this->isProfiling) {
>             throw new Exception\ProfilerCouldNotSnapshotOutsideProfile();
>         }
>         
>         // Snapshot logic here
>     }
> }
> 
> // Example class implementations
> class ProcessableProfile implements ProcessableProfileInterface, ProfileWithOutputInterface {
>     private $output;
> 
>     public function __construct($output) {
>         $this->output = $output;
>     }
> 
>     public function getOutput() {
>         return $this->output;
>     }
> 
>     // Other necessary implementations
> }
> ```
>
> Now, let’s use this `Profiler` in a practical scenario:
> ```php
> $profiler = new Profiler();
>
> try {
>     $profile = $profiler->profile(function($profiler) {
>         // Code to profile
>         sleep(1); // Simulate some workload
>         $profiler->snapshot();
>         return "Task Completed";
>     });
>     
>     echo "Execution time: " . $profile->getDuration() . " seconds\n";
>     echo "Output: " . $profile->getOutput();
> } catch (Exception\ProfilerCouldNotSnapshotOutsideProfile $e) {
>     echo "Snapshot called outside of profiling session.\n";
> }
> ```
>
> In this example:
> 1. The `profile()` method starts profiling and runs the given callable.
> 2. The callable performs some tasks and calls `snapshot()` to take a snapshot during profiling.
> 3. The `snapshot()` method checks if profiling is active and takes a snapshot or throws an exception if profiling has finished.
> 4. The profiling completes, and the duration and output are retrieved from the profile.
>
> This demonstrates the usage of the `snapshot` method within the profiling process. Clear and ready for action? 🚀 If you have more questions or code snippets, I’m here to help!
>
>> Is there any way to name the `snapshot` method better?
>
> Absolutely. Naming methods clearly can improve readability and maintainability. Here are some alternative names that might convey the purpose of the snapshot method more effectively:
> 1. **takeSnapshot**
> 2. **recordState**
> 3. **captureState**
> 4. **markPoint**
> 5. **saveCheckpoint**
>
> Each of these names indicates that the method is taking some form of measurement or recording the current state. Pick what resonates best with your project’s terminology and style!
>
> How do those sound? 🚀 If you need more, just let me know!
